### PR TITLE
Bug fix for sorted Firebase queries

### DIFF
--- a/src/ctree-loader/ctree-loader-behavior-firebase.html
+++ b/src/ctree-loader/ctree-loader-behavior-firebase.html
@@ -40,6 +40,18 @@ this license.
 
   'use strict';
 
+  /**
+   * Minimum step between values in Firebase. If this doesn't match the
+   * number of decimals for numbers in Firebase used for sorting it can
+   * result in skipping items in a list.  Note that this can't be the
+   * maximum decimals used by JS, because this is divided by 2 to resolve
+   * a bug with using 0 in Firebase queries.  Both Firebase and JS have
+   * the same decimal precision, so the precision used in Firebase needs
+   * to be enforced when setting the numbers (ex. using Number.toFixed()).
+   */
+  CTree.Loader.FIREBASE_MIN_DECIMAL_STEP = 1e-10;
+  CTree.Loader.FIREBASE_MAX_DECIMAL_PLACES = 10;
+
   CTree.LoaderBehavior = class extends CTree.LoaderBehaviorBase {
     static get properties() {
       return {
@@ -270,11 +282,19 @@ this license.
           loader.equalTo = value;
         } else if (ascending) {
           if (value || value === 0) {
+            // HACK: startAt doesn't work correctly when set to 0, so decrease by half step
+            if (value === 0) {
+              value -= CTree.Loader.FIREBASE_MIN_DECIMAL_STEP / 2;
+            }
             loader.startAt = value;
           }
           loader.limitToFirst = count;
         } else {
           if (value || value === 0) {
+            // HACK: endAt doesn't work correctly when set to 0, so increase by half step
+            if (value === 0) {
+              value += CTree.Loader.FIREBASE_MIN_DECIMAL_STEP / 2;
+            }
             loader.endAt = value;
           }
           loader.limitToLast = count;
@@ -416,9 +436,9 @@ this license.
       }
       if (!dataContainer.startAt && dataContainer.startAt !== 0) {
         if (dataContainer.ascending) {
-          dataContainer.startAt = Number.MIN_VALUE;
+          dataContainer.startAt = Number.MIN_SAFE_INTEGER;
         } else {
-          dataContainer.startAt = Number.MAX_VALUE;
+          dataContainer.startAt = Number.MAX_SAFE_INTEGER;
         }
       }
       if (!dataContainer.callbacks) {
@@ -451,9 +471,9 @@ this license.
         this._getData('elements', (data) => {
           dataContainer.loadGroup = false;
           if (dataContainer.ascending) {
-            dataContainer.startAt++;
+            dataContainer.startAt += CTree.Loader.FIREBASE_MIN_DECIMAL_STEP;
           } else {
-            dataContainer.startAt--;
+            dataContainer.startAt -= CTree.Loader.FIREBASE_MIN_DECIMAL_STEP;
           }
           dataContainer.nextCacheIndex = 1;
           dataContainer.cachedItems = data;

--- a/src/ctree-loader/ctree-loader-behavior-firebase.html
+++ b/src/ctree-loader/ctree-loader-behavior-firebase.html
@@ -40,15 +40,6 @@ this license.
 
   'use strict';
 
-  /**
-   * Minimum step between values in Firebase. If this doesn't match the number
-   * of decimals for numbers in Firebase used for sorting it can result in
-   * skipping items in a list.  The precision used in Firebase should be
-   * enforced when setting the numbers (ex. using Number.toFixed()).
-   */
-  CTree.Loader.FIREBASE_MIN_DECIMAL_STEP = 1e-10;
-  CTree.Loader.FIREBASE_MAX_DECIMAL_PLACES = 10;
-
   CTree.LoaderBehavior = class extends CTree.LoaderBehaviorBase {
     static get properties() {
       return {
@@ -153,6 +144,7 @@ this license.
         {
           key: 'rating',
           ascending: false,
+          minStepSize: 0.001,
         },
         {
           key: 'createdDate',
@@ -408,6 +400,7 @@ this license.
      *   {
      *     key: String,
      *     ascending: Boolean,
+     *     minStepSize: Number, // default=1, enforce when writing numbers (ex. using Number.toFixed()), otherwise could skip items
      *     startAt: Number,
      *     loadGroup: Boolean,
      *     cachedItems: [
@@ -465,11 +458,24 @@ this license.
         }
         this._getData('elements', (data) => {
           dataContainer.loadGroup = false;
-          if (dataContainer.ascending) {
-            dataContainer.startAt += CTree.Loader.FIREBASE_MIN_DECIMAL_STEP;
-          } else {
-            dataContainer.startAt -= CTree.Loader.FIREBASE_MIN_DECIMAL_STEP;
-          }
+          var oldStartAt = dataContainer.startAt;
+          var stepSize = dataContainer.minStepSize ? dataContainer.minStepSize : 1;
+          do {
+            if (dataContainer.ascending) {
+              dataContainer.startAt += stepSize;
+            } else {
+              dataContainer.startAt -= stepSize;
+            }
+            if (dataContainer.startAt === oldStartAt) {
+              // Size hasn't changed so must have exceeeded double precision (15
+              // decimals). Increase the step size and try again.
+              console.error('Applying step size of ' + stepSize
+                  + ' to start position ' + oldStartAt + ' for ' + dataContainer.key
+                  + ' made no change. Increasing step size and trying again.');
+              stepSize *= 10;
+              continue;
+            }
+          } while (false);
           dataContainer.nextCacheIndex = 1;
           dataContainer.cachedItems = data;
           // TODO: add/update elements in cTreeData

--- a/src/ctree-loader/ctree-loader-behavior-firebase.html
+++ b/src/ctree-loader/ctree-loader-behavior-firebase.html
@@ -41,13 +41,10 @@ this license.
   'use strict';
 
   /**
-   * Minimum step between values in Firebase. If this doesn't match the
-   * number of decimals for numbers in Firebase used for sorting it can
-   * result in skipping items in a list.  Note that this can't be the
-   * maximum decimals used by JS, because this is divided by 2 to resolve
-   * a bug with using 0 in Firebase queries.  Both Firebase and JS have
-   * the same decimal precision, so the precision used in Firebase needs
-   * to be enforced when setting the numbers (ex. using Number.toFixed()).
+   * Minimum step between values in Firebase. If this doesn't match the number
+   * of decimals for numbers in Firebase used for sorting it can result in
+   * skipping items in a list.  The precision used in Firebase should be
+   * enforced when setting the numbers (ex. using Number.toFixed()).
    */
   CTree.Loader.FIREBASE_MIN_DECIMAL_STEP = 1e-10;
   CTree.Loader.FIREBASE_MAX_DECIMAL_PLACES = 10;
@@ -281,21 +278,19 @@ this license.
         if (!count || count <= 0) {
           loader.equalTo = value;
         } else if (ascending) {
-          if (value || value === 0) {
-            // HACK: startAt doesn't work correctly when set to 0, so decrease by half step
-            if (value === 0) {
-              value -= CTree.Loader.FIREBASE_MIN_DECIMAL_STEP / 2;
-            }
+          if (value) {
             loader.startAt = value;
+          } else if (value === 0) {
+            // required to behave correctly for a 0 value
+            loader.startAt = "0";
           }
           loader.limitToFirst = count;
         } else {
-          if (value || value === 0) {
-            // HACK: endAt doesn't work correctly when set to 0, so increase by half step
-            if (value === 0) {
-              value += CTree.Loader.FIREBASE_MIN_DECIMAL_STEP / 2;
-            }
+          if (value) {
             loader.endAt = value;
+          } else if (value === 0) {
+            // required to behave correctly for a 0 value
+            loader.endAt = "0";
           }
           loader.limitToLast = count;
         }


### PR DESCRIPTION
I found an issue with sorting Firebase queries where it didn't always return all items.  It turns out startAt and endAt treat a 0 numeric value as undefined, so you get the wrong item(s).  This is resolved by using the string "0" instead.

I also realized that the step size for numbers used for sorting was implicitly 1, because in cases where we started looking for the next items after a value, we incremented the start value by 1.  I resolved this by adding a new step size constant, which will need to align with the number of decimal places used when writing these values, otherwise we may miss some items from the list.