### PR TITLE
Update app to support multiple contexts

### DIFF
--- a/src/ctree-app/ctree-app-icon.html
+++ b/src/ctree-app/ctree-app-icon.html
@@ -28,9 +28,9 @@ this license.
 -->
 
 <link rel="import" href="../../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../../bower_components/iron-icon/iron-icon.html">
 <link rel="import" href="../../bower_components/iron-meta/iron-meta.html">
 <link rel="import" href="../../bower_components/paper-button/paper-button.html">
-<link rel="import" href="../../bower_components/paper-icon/paper-icon.html">
 
 <dom-module id="ctree-app-icon">
   <template>

--- a/src/ctree-app/ctree-app-icon.html
+++ b/src/ctree-app/ctree-app-icon.html
@@ -1,0 +1,72 @@
+<!--
+@license
+Copyright (c) 2017 Foundation For an Innovative Future (InnovativeFuture.org)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or any
+later version.
+
+Foundation For an Innovative Future reserves the right to release the
+covered work, in part or in whole, under a different open source
+license and/or with specific copyleft exclusions.  Such a release
+would not invalidate the license for this project, although the
+project released with a modified license would not be considered
+part of this covered work or subject to the copyleft portions of this
+license even if the projects are identical.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Please email contact@innovativeFuture.org for inquiries related to
+this license.
+-->
+
+<link rel="import" href="../../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../../bower_components/iron-meta/iron-meta.html">
+<link rel="import" href="../../bower_components/paper-button/paper-button.html">
+<link rel="import" href="../../bower_components/paper-icon/paper-icon.html">
+
+<dom-module id="ctree-app-icon">
+  <template>
+    <style>
+      :host {
+        display: inline-block;
+        padding: 8px 8px 0 8px;
+      }
+      paper-button {
+        min-width: 0;
+        padding: 0px;
+        margin: 0;
+      }
+      iron-icon {
+        width: 48px;
+        height: 48px;
+        padding: 0;
+      }
+    </style>
+
+    <iron-meta key="rootPath" value="{{rootPath}}"></iron-meta>
+
+    <a name="Collaboraton Trees" class="ctree-item" href="[[rootPath]]">
+      <paper-button>
+        <iron-icon src="[[rootPath]]/images/app-icon-144.png"></iron-icon>
+      </paper-button>
+    </a>
+  </template>
+
+  <script>
+    class CTreeAppIcon extends Polymer.Element {
+
+      static get is() { return 'ctree-app-icon'; }
+    }
+
+    // Register custom element definition using standard platform API
+    customElements.define(CTreeAppIcon.is, CTreeAppIcon);
+  </script>
+</dom-module>

--- a/src/ctree-app/ctree-app.html
+++ b/src/ctree-app/ctree-app.html
@@ -78,8 +78,10 @@ this license.
     <!-- TODO: <ctree-import href="/src/ctree-app/ctree-catalog.html"></ctree-import> -->
     <iron-location path="{{path}}" dwell-time="800"></iron-location>
 
-    <ctree-landing hidden$="[[!isRootPath(path, rootPath)]]"></ctree-landing>
-    <ctree-catalog hidden$="[[isRootPath(path, rootPath)]]"></ctree-catalog>
+    <!-- TODO: uncomment once merge with landing page branch ->
+    <!--<ctree-landing hidden$="[[!isRootPath(path, rootPath)]]"></ctree-landing>
+    <ctree-catalog hidden$="[[isRootPath(path, rootPath)]]"></ctree-catalog>-->
+    <ctree-catalog></ctree-catalog>
   </template>
 
   <script>

--- a/src/ctree-app/ctree-app.html
+++ b/src/ctree-app/ctree-app.html
@@ -28,28 +28,8 @@ this license.
 -->
 
 <link rel="import" href="../../bower_components/polymer/polymer-element.html">
-<link rel="import" href="../../bower_components/app-layout/app-drawer-layout/app-drawer-layout.html">
-<link rel="import" href="../../bower_components/app-layout/app-drawer/app-drawer.html">
-<link rel="import" href="../../bower_components/app-layout/app-scroll-effects/app-scroll-effects.html">
-<link rel="import" href="../../bower_components/app-layout/app-header/app-header.html">
-<link rel="import" href="../../bower_components/app-layout/app-header-layout/app-header-layout.html">
-<link rel="import" href="../../bower_components/app-layout/app-toolbar/app-toolbar.html">
-<link rel="import" href="../../bower_components/iron-list/iron-list.html">
 <link rel="import" href="../../bower_components/iron-location/iron-location.html">
-<link rel="import" href="../../bower_components/iron-location/iron-query-params.html">
 <link rel="import" href="../../bower_components/iron-meta/iron-meta.html">
-<link rel="import" href="../../bower_components/iron-scroll-threshold/iron-scroll-threshold.html">
-<link rel="import" href="../../bower_components/iron-selector/iron-selector.html">
-<link rel="import" href="../../bower_components/paper-badge/paper-badge.html">
-<link rel="import" href="../../bower_components/paper-button/paper-button.html">
-<link rel="import" href="../../bower_components/paper-fab/paper-fab.html">
-<link rel="import" href="../../bower_components/paper-icon-button/paper-icon-button.html">
-<link rel="import" href="../../bower_components/paper-input/paper-input.html">
-<link rel="import" href="../../bower_components/paper-spinner/paper-spinner.html">
-<link rel="import" href="../../bower_components/paper-tabs/paper-tabs.html">
-<link rel="import" href="../../bower_components/paper-tooltip/paper-tooltip.html">
-<link rel="import" href="../../bower_components/polymerfire/firebase-app.html">
-<link rel="import" href="../../bower_components/polymerfire/firebase-auth.html">
 
 <!-- This MUST be done before importing any cTree elements -->
 <script>
@@ -72,278 +52,34 @@ this license.
   };*/
 </script>
 
-<link rel="import" href="../ctree-dialogs/ctree-element-dialog-accessor.html">
-<link rel="import" href="../ctree-dialogs/ctree-new-element-dialog-accessor.html">
-<link rel="import" href="../ctree-dialogs/ctree-user-dialog-accessor.html">
 <link rel="import" href="../ctree-import/ctree-import.html">
 <link rel="import" href="../ctree-loader/ctree-loader-behavior.html"> <!-- needs to be added to fix crash when showing dialog on refresh -->
-<link rel="import" href="../ctree-toggle-button/ctree-toggle-button.html">
 
 <link rel="import" href="icons.html">
-
-<script>
-  // TODO: create a loader for tree types or add to ctree-loader
-  var ctreePages = {all: {label: "All Saved cTrees",	icon: "/images/app-icon-32.png", saved: true},
-      	          future: {label: "Future City",	icon: "/images/app-icon-32.png", saved: true},
-      	          recipes: {label: "Recipes",		icon: "/images/app-icon-32.png", saved: true},
-      	          newCTrees: {label: "New cTrees",	icon: "/images/app-icon-32.png", saved: false},
-      	          lyrics: {label: "Song Lyrics",	icon: "/images/app-icon-32.png", saved: true},
-      	          test: {label: "Test",	icon: "/images/app-icon-32.png", saved: true}};
-  var ctreeSavedPages = ["all", "future", "recipes", "newCTrees", "lyrics", "test"];
-</script>
+<link rel="import" href="ctree-landing.html">
+<link rel="import" href="ctree-catalog.html">
 
 <dom-module id="ctree-app">
   <template>
     <style>
       :host {
         display: block;
-        --app-primary-color: #5F9F00;
-        --app-secondary-color: black;
       }
-      app-drawer-layout:not([narrow]) [drawer-toggle] {
-        display: none;
-      }
-      app-drawer app-toolbar {
-        background-color: #4F7F00;
-        color: #fff;
-      }
-      app-header-layout {
-        height: 100vh;
-      }
-      app-header {
-        background-color: var(--app-primary-color);
-        color: #fff;
-      }
-      app-header paper-icon-button {
-        --paper-icon-button-ink-color: white;
-      }
-      app-header paper-badge {
-        display: none;
-        --paper-badge-margin-left: -14px;
-        --paper-badge-margin-bottom: -14px;
-      }
-      paper-tab {
-        width: 0;
-      }
-      paper-tab[link] a {
-        @apply --layout-horizontal;
-        @apply --layout-center-center;
-        color: #fff;
-        text-decoration: none;
-      }
-      paper-tab iron-icon {
-        padding-right: 2px;
-      }
-      .tabTooltip {
-        visibility: hidden;
-      }
-      paper-button {
-        text-transform: none;
-      }
-      paper-button iron-icon {
-        padding-right: 8px;
-      }
-      .nav-drawer {
-        bottom: 0;
-      }
-      .nav-content {
-        padding: 12px 8px;
-        height: 100%;
-      }
-      .nav-content paper-input {
-        padding: 0 12px;
-      }
-      .drawer-list a {
-        display: block;
-        padding: 0;
-        line-height: 32px;
-        text-decoration: none;
-        color: var(--app-secondary-color);
-      }
-      .drawer-list div {
-        display: flex;
-        justify-content: space-between;
-      }
-      .drawer-list a.iron-selected {
-        color: black;
-        font-weight: bold;
-      }
-      .drawer-list a.subroute {
-        padding-left: 32px;
-      }
-      #elementPreviewList {
-        @apply --layout-fit;
-        overflow-y: auto;
-        -webkit-overflow-scrolling: touch;
-
-        padding: 10px;
-        padding-top: 10px;
-        padding-bottom: 48px;
-      }
-      ctree-element-preview {
-        width: 280px;
-        height: 320px;
-      }
-      #loadingIndicator {
-        position: absolute;
-        top: auto !important;
-        bottom: -36px;
-        left: 0;
-        right: 0;
-        font-size: 16px;
-        text-align: center;
-      }
-      #addButton {
-        position: absolute;
-        bottom: 24px;
-        right: 24px;
-      }
-      .notifications-drawer {
-        top: -20px;
-        bottom: -72px;
-      }
-      .notifications-content {
-        height: 100%;
-      }
-      .notifications-header div {
-        display: inline-block;
-        padding: 12px 16px;
-        font-weight: 500;
-        font-size: 16px
-      }
-      .notifications-header paper-icon-button {
-        float: right;
-        margin: 4px;
-      }
-      paper-icon-button[hidden] {
+      ctree-landing[hidden], ctree-catalog[hidden] {
         display: none !important;
-      }
-      ctree-element-preview[hidden] {
-        display: none !important;
-      }
-      @media (max-width: 340px) {
-        .tabLabel {
-          display: none;
-        }
-        .tabTooltip {
-          visibility: visible;
-        }
       }
     </style>
 
     <firebase-app id="firebase"></firebase-app>
     <firebase-auth id="auth"></firebase-auth>
 
+    <!-- TODO: <ctree-import href="/src/ctree-app/ctree-landing.html"></ctree-import> -->
     <iron-meta key="rootPath" value="{{rootPath}}"></iron-meta>
-    <ctree-import id="importLoader" href="/src/ctree-loader/ctree-list-loader.html" required="ListLoader" on-loading-changed="_importLoaderLoadingChanged"></ctree-import>
-    <ctree-import id="importPreview" href="/src/ctree-element-preview/ctree-element-preview.html"></ctree-import>
+    <!-- TODO: <ctree-import href="/src/ctree-app/ctree-catalog.html"></ctree-import> -->
+    <iron-location path="{{path}}" dwell-time="800"></iron-location>
 
-    <iron-location path="{{path}}" query="{{query}}" dwell-time="800"></iron-location>
-    <iron-query-params id="params" params-string="{{query}}" params-object="{{queryParams}}"></iron-query-params>
-    <ctree-element-dialog-accessor id="elementDialog" ctree-key="[[ctreeKey]]"></ctree-element-dialog-accessor>
-    <ctree-new-element-dialog-accessor id="newElementDialog" ctree-key="[[ctreeKey]]"></ctree-new-element-dialog-accessor>
-    <ctree-user-dialog-accessor id="userDialog" ctree-key="[[ctreeKey]]"></ctree-user-dialog-accessor>
-
-    <ctree-list-loader id="loader" ctree-key="[[ctreeKey]]" name="{{ctreeName}}" current-items="{{pageListItems}}" current-loading="{{loadingListItems}}" current-has-more="{{hasMoreListItems}}"></ctree-list-loader>
-
-    <!-- <app-drawer-layout fullbleed> -->
-
-      <!-- Navigation drawer -->
-      <!--<app-drawer slot="drawer" id="navDrawer" class="nav-drawer" swipe-open>
-        <app-toolbar>cTrees</app-toolbar>
-        <div class="nav-content">
-          <paper-input label="Search" value="{{searchText}}" no-label-float>
-            <iron-icon icon="search" slot="prefix"></iron-icon>
-            <paper-icon-button slot="suffix" hidden$="[[!searchText]]" on-tap="_clearSearch" icon="clear" alt="clear" title="clear"></paper-icon-button>
-          </paper-input>
-
-          <iron-selector selected="[[page]]" attr-for-selected="name" class="drawer-list" fallback-selection="test" role="navigation">
-            <template is="dom-repeat" items="[[_getCTreeList(navList.splices,rootPath,searchText)]]" as="item">
-              <div>
-                <a name="[[item.name]]" class="ctree-item" href="[[rootPath]]/[[item.name]]">
-                  <paper-button>
-                    <iron-icon src="[[item.data.icon]]"></iron-icon>
-                    [[item.data.label]]
-                  </paper-button>
-                </a>
-                <ctree-toggle-button id="saveCTree" hidden$="[[!searchText]]" icon-unchecked="bookmark-border" icon-checked="bookmark" checked="{{item.data.saved}}" title-unchecked="Not Bookmarked" title-checked="Bookmarked"></ctree-toggle-button>
-              </div>
-            </template>
-          </iron-selector>
-        </div>
-      </app-drawer>-->
-
-      <app-header-layout id="mainLayout" has-scrolling-region>
-        <app-header slot="header" fixed effects="waterfall">
-          <app-toolbar>
-            <!--<paper-icon-button icon="menu" drawer-toggle></paper-icon-button>-->
-            <div main-title>[[ctreeName]]</div>
-            <paper-icon-button icon="search" on-tap="showSearch"></paper-icon-button>
-            <!--<paper-icon-button icon="account-circle" on-tap="showAccountDialog"></paper-icon-button>
-            <paper-icon-button icon="account-stats" on-tap="showAccountStats"></paper-icon-button>
-            <paper-icon-button id="notifications" icon="notifications-none" on-tap="showNotifications"></paper-icon-button>
-            <paper-badge for="notifications"></paper-badge>-->
-          </app-toolbar>
-          <!-- </app-toolbar><app-toolbar style="height: 36px;">
-            <paper-tabs selected="{{subpage}}" attr-for-selected="name" fallback-selection="suggested" bottom-item>
-              <paper-tab id="suggestedTab" name="suggested" link>
-                <a href="[[rootPath]]/[[ctreeKey]]/suggested" tabindex="-1">
-                  <iron-icon icon="suggested"></iron-icon><div class="tabLabel">SUGGESTED</div>
-                </a>
-              </paper-tab>
-              <paper-tab id="bookmarksTab" name="bookmarked" link>
-                <a href="[[rootPath]]/[[ctreeKey]]/bookmarked" tabindex="-1">
-                  <iron-icon icon="bookmark"></iron-icon><div class="tabLabel">BOOKMARKS</div>
-                </a>
-              </paper-tab>
-              <paper-tab id="historyTab" name="history" link>
-                <a href="[[rootPath]]/[[ctreeKey]]/history" tabindex="-1">
-                  <iron-icon icon="history"></iron-icon><div class="tabLabel">HISTORY</div>
-                </a>
-              </paper-tab>
-            </paper-tabs>
-            <paper-tooltip class="tabTooltip" for="suggestedTab" offset="-8">Suggested</paper-tooltip>
-            <paper-tooltip class="tabTooltip" for="bookmarksTab" offset="-8">Bookmarks</paper-tooltip>
-            <paper-tooltip class="tabTooltip" for="historyTab" offset="-8">History</paper-tooltip>
-          </app-toolbar> -->
-
-        </app-header>
-
-        <iron-list id="elementPreviewList" items="[[pageListItems]]" as="item" grid>
-          <!-- HACK: added  hidden$="[[!item]]" to prevent phantom items from being added -->
-          <template>
-            <ctree-element-preview ctree-key="[[page]]" list-item="[[item]]" hidden$="[[!item]]"></ctree-element-preview>
-          </template>
-
-          <div id="loadingIndicator" hidden$="[[!loadingListItems]]">
-            <paper-spinner active$="[[loadingListItems]]"></paper-spinner> Loading more
-          </div>
-        </iron-list>
-
-        <iron-scroll-threshold id="scrollThreshold"
-            lower-threshold="500"
-            scroll-target="elementPreviewList"
-            on-lower-threshold="loadMoreListItems">
-        </iron-scroll-threshold>
-
-        <!-- <paper-fab id="addButton" icon="add" title="Add" on-tap="_addElement"></paper-fab> -->
-
-        <!-- Notification drawer -->
-        <app-drawer id="notificationsDrawer" class="notifications-drawer" align="end" on-app-drawer-transitioned="notificationsDrawerTransitioned">
-          <div class="notifications-content" align="left">
-            <div class="notifications-header">
-              <div>Notifications</div>
-              <paper-icon-button on-tap="clearNotifications" icon="playlist-add-check"></paper-icon-button>
-            </div>
-            <iron-list items="[[notifications]]" as="item">
-              <template>
-                <!-- TODO -->
-              </template>
-            </iron-list>
-          </div>
-        </app-drawer>
-      </app-header-layout>
-    <!-- </app-drawer-layout> -->
+    <ctree-landing hidden$="[[!isRootPath(path, rootPath)]]"></ctree-landing>
+    <ctree-catalog hidden$="[[isRootPath(path, rootPath)]]"></ctree-catalog>
   </template>
 
   <script>
@@ -357,38 +93,7 @@ this license.
             type: String,
             value: ''
           },
-
-          page: {
-            type: String,
-            observer: '_pageChanged',
-          },
-
-          searchText: {
-            type: String,
-            observer: '_searchTextChanged',
-            value: function() {
-              return '';
-            }
-          },
-
-          navList: {
-            type: Array,
-            value: function() {
-              return [];
-            }
-          },
-
-          notifications: Array,
         };
-      }
-
-      static get observers() {
-        return [
-          '_dialogParamChanged(queryParams.d)',
-          '_pathChanged(path)',
-          '_subpageChanged(subpage)',
-          '_loadingListItemsChanged(loadingListItems)',
-        ];
       }
 
       ready() {
@@ -408,197 +113,8 @@ this license.
         // TODO:
       }
 
-      showSearch() {
-        // TODO: initiate search input
-      }
-
-      showNotifications() {
-        // TODO: show notifications in dialog below button when larger width (i.e. not on phones)
-    	   this.$.notificationsDrawer.toggle();
-      }
-
-      notificationsDrawerTransitioned() {
-        this.$.elementPreviewList.style.overflowY = this.$.notificationsDrawer.opened ? "hidden" : "auto";
-      }
-
-      clearNotifications() {
-        // TODO: clear all notifications & update notifications indicator in header
-      }
-
-      showAccountDialog() {
-        var dialog = this.$.userDialog;
-        // TODO: show account details in account dialog
-        dialog.page = 'details';
-        dialog.open();
-      }
-
-      showAccountStats() {
-        var dialog = this.$.userDialog;
-        // TODO: show account stats in account dialog
-        dialog.page = 'stats';
-        dialog.open();
-      }
-
-      loadMoreListItems() {
-        if (this.$.importLoader.loaded) {
-          this.$.loader.loadCurrent();
-        } else {
-          this.$.importLoader.load();
-        }
-      }
-
-      _clearSearch() {
-        this.searchText = '';
-      }
-
-      _getCTreeSaveIcon(saved) {
-        return saved ? 'bookmark' : 'bookmark-border';
-      }
-
-      _toggleCTreeSaved() {
-        // TODO: determine which ctree this was clicked for and toggle its data.saved value
-      }
-
-      _importLoaderLoadingChanged(e) {
-        if (!e.detail.value && this.$.importLoader.loaded
-            && !this.$.importPreview.loading && !this.$.importPreview.loaded) {
-          this.$.importPreview.load();
-          this.loadMoreListItems();
-        }
-      }
-
-      _loadingListItemsChanged(loadingListItems) {
-        if (!loadingListItems) {
-          this.$.scrollThreshold.clearTriggers();
-        }
-      }
-
-      _getCTreeList() {
-        // TODO: make conditional on if search is active and what search text is
-        /*if (this.navList) {
-          this.navList.length = 0;
-        } else {
-          this.navList = [];
-        }*/
-        var newNavList = [];
-        var searchTextLower = this.searchText ? this.searchText.toLowerCase() : '';
-        if (CTree.firebaseConfig) {
-          // TODO: get list of cTrees from Firebase instead of using hardcoded pages
-        } else {
-          for (var i = 0; i < ctreeSavedPages.length; i++) {
-            var name = ctreeSavedPages[i];
-            var pageData = ctreePages[name];
-            if (!pageData.icon.startsWith(this.rootPath)) {
-              pageData.icon = this.rootPath + pageData.icon;
-            }
-
-            if (this.searchText) {
-              if (pageData.label.toLowerCase().indexOf(searchTextLower) !== -1) {
-                  newNavList.push({name: name, data: pageData});
-              }
-            } else {
-              if (pageData.saved) {
-                newNavList.push({name: name, data: pageData});
-              }
-            }
-          }
-        }
-
-        return newNavList;
-      }
-
-      _dialogParamChanged(dialogParam) {
-        if (dialogParam === 'element') {
-          this.$.elementDialog.open();
-        } else if (dialogParam === 'user') {
-          this.$.userDialog.open();
-        }
-      }
-
-      _pathChanged(fullPath) {
-        if (fullPath.startsWith(this.rootPath)) {
-          fullPath = fullPath.substr(this.rootPath.length);
-        }
-        var pathSegments = fullPath.split('/');
-        if (pathSegments.length > 1) {
-          var page;
-          // TODO: default to
-          if (CTree.firebaseConfig || ctreeSavedPages.indexOf(pathSegments[1]) >= 0) {
-            page = pathSegments[1];
-          } else if (CTree.firebaseConfig) {
-            // TODO: default to something other than test
-            page = "test"
-          } else {
-            // default to first saved page
-            page = ctreeSavedPages[0];
-          }
-          var subpage;
-          if (pathSegments.length > 2) {
-            subpage = pathSegments[2];
-            if (subpage != 'bookmarked' && subpage != 'history') {
-              subpage = 'suggested';
-            }
-          } else {
-            subpage = 'suggested';
-          }
-        } else {
-          if (CTree.firebaseConfig) {
-            page = "test"
-          } else {
-            page = ctreeSavedPages[0];
-          }
-          subpage = 'suggested';
-        }
-        var forceSubpageChanged = (this.page != page && this.subpage == subpage);
-        this.page = page;
-        this.subpage = subpage;
-        if (forceSubpageChanged) {
-          this._subpageChanged(subpage);
-        }
-      }
-
-      _pageChanged(page) {
-        if (this.rootPath && this.rootPath.length > 0) {
-          this.ctreeKey = this.rootPath + (page && page.length > 0 ? '/' + page : '');
-        } else {
-          this.ctreeKey = page;
-        }
-      }
-
-      _searchTextChanged(searchText) {
-        // TODO:
-      }
-
-      _subpageChanged(subpage) {
-        this.$.loader.currentName = subpage;
-        this.$.scrollThreshold.clearTriggers();
-        // This must be delayed to prevent issue with rootPath being set after trying to load items, which triggers loading component
-        Polymer.RenderStatus.afterNextRender(this, () => {
-          if (!this.$.importLoader.loaded || this.$.loader.currentItems.length == 0) {
-            this.loadMoreListItems();
-          }
-        });
-      }
-
-      // TODO: respond to element changes via the ctree element loader
-      _bookmarkChanged(e) {
-        var element = e.detail.element;
-        // TODO: remove event from bookmarked list (may not be found)
-        if (e.detail.bookmarked) {
-          // TODO: add event to top of bookmarked list
-        }
-        // TODO: start checking for duplicates as loading bookmarked items (may have added manually)
-      }
-
-      _getTempNotifications() {
-    	  // TODO:
-    	  return [];
-      }
-
-      _addElement() {
-        var dialog = this.$.newElementDialog;
-        // TODO: add parameters if needed
-        dialog.open();
+      isRootPath(path, rootPath) {
+        return path === rootPath + "/";
       }
     }
 

--- a/src/ctree-app/ctree-catalog.html
+++ b/src/ctree-app/ctree-catalog.html
@@ -1,0 +1,570 @@
+<!--
+@license
+Copyright (c) 2017 Foundation For an Innovative Future (InnovativeFuture.org)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or any
+later version.
+
+Foundation For an Innovative Future reserves the right to release the
+covered work, in part or in whole, under a different open source
+license and/or with specific copyleft exclusions.  Such a release
+would not invalidate the license for this project, although the
+project released with a modified license would not be considered
+part of this covered work or subject to the copyleft portions of this
+license even if the projects are identical.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Please email contact@innovativeFuture.org for inquiries related to
+this license.
+-->
+
+<link rel="import" href="../../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../../bower_components/app-layout/app-drawer-layout/app-drawer-layout.html">
+<link rel="import" href="../../bower_components/app-layout/app-drawer/app-drawer.html">
+<link rel="import" href="../../bower_components/app-layout/app-scroll-effects/app-scroll-effects.html">
+<link rel="import" href="../../bower_components/app-layout/app-header/app-header.html">
+<link rel="import" href="../../bower_components/app-layout/app-header-layout/app-header-layout.html">
+<link rel="import" href="../../bower_components/app-layout/app-toolbar/app-toolbar.html">
+<link rel="import" href="../../bower_components/iron-list/iron-list.html">
+<link rel="import" href="../../bower_components/iron-location/iron-location.html">
+<link rel="import" href="../../bower_components/iron-location/iron-query-params.html">
+<link rel="import" href="../../bower_components/iron-meta/iron-meta.html">
+<link rel="import" href="../../bower_components/iron-scroll-threshold/iron-scroll-threshold.html">
+<link rel="import" href="../../bower_components/iron-selector/iron-selector.html">
+<link rel="import" href="../../bower_components/paper-badge/paper-badge.html">
+<link rel="import" href="../../bower_components/paper-button/paper-button.html">
+<link rel="import" href="../../bower_components/paper-fab/paper-fab.html">
+<link rel="import" href="../../bower_components/paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../../bower_components/paper-input/paper-input.html">
+<link rel="import" href="../../bower_components/paper-spinner/paper-spinner.html">
+<link rel="import" href="../../bower_components/paper-tabs/paper-tabs.html">
+<link rel="import" href="../../bower_components/paper-tooltip/paper-tooltip.html">
+<link rel="import" href="../../bower_components/polymerfire/firebase-app.html">
+<link rel="import" href="../../bower_components/polymerfire/firebase-auth.html">
+
+<link rel="import" href="../ctree-dialogs/ctree-element-dialog-accessor.html">
+<link rel="import" href="../ctree-dialogs/ctree-new-element-dialog-accessor.html">
+<link rel="import" href="../ctree-dialogs/ctree-user-dialog-accessor.html">
+<link rel="import" href="../ctree-import/ctree-import.html">
+<link rel="import" href="../ctree-loader/ctree-loader-behavior.html"> <!-- needs to be added to fix crash when showing dialog on refresh -->
+<link rel="import" href="../ctree-toggle-button/ctree-toggle-button.html">
+
+<link rel="import" href="icons.html">
+
+<script>
+  // TODO: create a loader for tree types or add to ctree-loader
+  var ctreePages = {all: {label: "All Saved cTrees",	icon: "/images/app-icon-32.png", saved: true},
+      	          future: {label: "Future City",	icon: "/images/app-icon-32.png", saved: true},
+      	          recipes: {label: "Recipes",		icon: "/images/app-icon-32.png", saved: true},
+      	          newCTrees: {label: "New cTrees",	icon: "/images/app-icon-32.png", saved: false},
+      	          lyrics: {label: "Song Lyrics",	icon: "/images/app-icon-32.png", saved: true},
+      	          test: {label: "Test",	icon: "/images/app-icon-32.png", saved: true}};
+  var ctreeSavedPages = ["all", "future", "recipes", "newCTrees", "lyrics", "test"];
+</script>
+
+<dom-module id="ctree-catalog">
+  <template>
+    <style>
+      :host {
+        display: block;
+        --app-primary-color: #5F9F00;
+        --app-secondary-color: black;
+      }
+      app-drawer-layout:not([narrow]) [drawer-toggle] {
+        display: none;
+      }
+      app-drawer app-toolbar {
+        background-color: #4F7F00;
+        color: #fff;
+      }
+      app-header-layout {
+        height: 100vh;
+      }
+      app-header {
+        background-color: var(--app-primary-color);
+        color: #fff;
+      }
+      app-header paper-icon-button {
+        --paper-icon-button-ink-color: white;
+      }
+      app-header paper-badge {
+        display: none;
+        --paper-badge-margin-left: -14px;
+        --paper-badge-margin-bottom: -14px;
+      }
+      paper-tab {
+        width: 0;
+      }
+      paper-tab[link] a {
+        @apply --layout-horizontal;
+        @apply --layout-center-center;
+        color: #fff;
+        text-decoration: none;
+      }
+      paper-tab iron-icon {
+        padding-right: 2px;
+      }
+      .tabTooltip {
+        visibility: hidden;
+      }
+      paper-button {
+        text-transform: none;
+      }
+      paper-button iron-icon {
+        padding-right: 8px;
+      }
+      .nav-drawer {
+        bottom: 0;
+      }
+      .nav-content {
+        padding: 12px 8px;
+        height: 100%;
+      }
+      .nav-content paper-input {
+        padding: 0 12px;
+      }
+      .drawer-list a {
+        display: block;
+        padding: 0;
+        line-height: 32px;
+        text-decoration: none;
+        color: var(--app-secondary-color);
+      }
+      .drawer-list div {
+        display: flex;
+        justify-content: space-between;
+      }
+      .drawer-list a.iron-selected {
+        color: black;
+        font-weight: bold;
+      }
+      .drawer-list a.subroute {
+        padding-left: 32px;
+      }
+      #elementPreviewList {
+        @apply --layout-fit;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+
+        padding: 10px;
+        padding-top: 10px;
+        padding-bottom: 48px;
+      }
+      ctree-element-preview {
+        width: 280px;
+        height: 320px;
+      }
+      #loadingIndicator {
+        position: absolute;
+        top: auto !important;
+        bottom: -36px;
+        left: 0;
+        right: 0;
+        font-size: 16px;
+        text-align: center;
+      }
+      #addButton {
+        position: absolute;
+        bottom: 24px;
+        right: 24px;
+      }
+      .notifications-drawer {
+        top: -20px;
+        bottom: -72px;
+      }
+      .notifications-content {
+        height: 100%;
+      }
+      .notifications-header div {
+        display: inline-block;
+        padding: 12px 16px;
+        font-weight: 500;
+        font-size: 16px
+      }
+      .notifications-header paper-icon-button {
+        float: right;
+        margin: 4px;
+      }
+      paper-icon-button[hidden] {
+        display: none !important;
+      }
+      ctree-element-preview[hidden] {
+        display: none !important;
+      }
+      @media (max-width: 340px) {
+        .tabLabel {
+          display: none;
+        }
+        .tabTooltip {
+          visibility: visible;
+        }
+      }
+    </style>
+
+    <firebase-app id="firebase"></firebase-app>
+    <firebase-auth id="auth"></firebase-auth>
+
+    <iron-meta key="rootPath" value="{{rootPath}}"></iron-meta>
+    <ctree-import id="importLoader" href="/src/ctree-loader/ctree-list-loader.html" required="ListLoader" on-loading-changed="_importLoaderLoadingChanged"></ctree-import>
+    <ctree-import id="importPreview" href="/src/ctree-element-preview/ctree-element-preview.html"></ctree-import>
+
+    <iron-location path="{{path}}" query="{{query}}" dwell-time="800"></iron-location>
+    <iron-query-params id="params" params-string="{{query}}" params-object="{{queryParams}}"></iron-query-params>
+    <ctree-element-dialog-accessor id="elementDialog" ctree-key="[[ctreeKey]]"></ctree-element-dialog-accessor>
+    <ctree-new-element-dialog-accessor id="newElementDialog" ctree-key="[[ctreeKey]]"></ctree-new-element-dialog-accessor>
+    <ctree-user-dialog-accessor id="userDialog" ctree-key="[[ctreeKey]]"></ctree-user-dialog-accessor>
+
+    <ctree-list-loader id="loader" ctree-key="[[ctreeKey]]" name="{{ctreeName}}" current-items="{{pageListItems}}" current-loading="{{loadingListItems}}" current-has-more="{{hasMoreListItems}}"></ctree-list-loader>
+
+    <!-- <app-drawer-layout fullbleed> -->
+
+      <!-- Navigation drawer -->
+      <!--<app-drawer slot="drawer" id="navDrawer" class="nav-drawer" swipe-open>
+        <app-toolbar>cTrees</app-toolbar>
+        <div class="nav-content">
+          <paper-input label="Search" value="{{searchText}}" no-label-float>
+            <iron-icon icon="search" slot="prefix"></iron-icon>
+            <paper-icon-button slot="suffix" hidden$="[[!searchText]]" on-tap="_clearSearch" icon="clear" alt="clear" title="clear"></paper-icon-button>
+          </paper-input>
+
+          <iron-selector selected="[[page]]" attr-for-selected="name" class="drawer-list" fallback-selection="test" role="navigation">
+            <template is="dom-repeat" items="[[_getCTreeList(navList.splices,rootPath,searchText)]]" as="item">
+              <div>
+                <a name="[[item.name]]" class="ctree-item" href="[[rootPath]]/[[item.name]]">
+                  <paper-button>
+                    <iron-icon src="[[item.data.icon]]"></iron-icon>
+                    [[item.data.label]]
+                  </paper-button>
+                </a>
+                <ctree-toggle-button id="saveCTree" hidden$="[[!searchText]]" icon-unchecked="bookmark-border" icon-checked="bookmark" checked="{{item.data.saved}}" title-unchecked="Not Bookmarked" title-checked="Bookmarked"></ctree-toggle-button>
+              </div>
+            </template>
+          </iron-selector>
+        </div>
+      </app-drawer>-->
+
+      <app-header-layout id="mainLayout" has-scrolling-region>
+        <app-header slot="header" fixed effects="waterfall">
+          <app-toolbar>
+            <!--<paper-icon-button icon="menu" drawer-toggle></paper-icon-button>-->
+            <div main-title>[[ctreeName]]</div>
+            <paper-icon-button icon="search" on-tap="showSearch"></paper-icon-button>
+            <!--<paper-icon-button icon="account-circle" on-tap="showAccountDialog"></paper-icon-button>
+            <paper-icon-button icon="account-stats" on-tap="showAccountStats"></paper-icon-button>
+            <paper-icon-button id="notifications" icon="notifications-none" on-tap="showNotifications"></paper-icon-button>
+            <paper-badge for="notifications"></paper-badge>-->
+          </app-toolbar>
+          <!-- </app-toolbar><app-toolbar style="height: 36px;">
+            <paper-tabs selected="{{subpage}}" attr-for-selected="name" fallback-selection="suggested" bottom-item>
+              <paper-tab id="suggestedTab" name="suggested" link>
+                <a href="[[rootPath]]/[[ctreeKey]]/suggested" tabindex="-1">
+                  <iron-icon icon="suggested"></iron-icon><div class="tabLabel">SUGGESTED</div>
+                </a>
+              </paper-tab>
+              <paper-tab id="bookmarksTab" name="bookmarked" link>
+                <a href="[[rootPath]]/[[ctreeKey]]/bookmarked" tabindex="-1">
+                  <iron-icon icon="bookmark"></iron-icon><div class="tabLabel">BOOKMARKS</div>
+                </a>
+              </paper-tab>
+              <paper-tab id="historyTab" name="history" link>
+                <a href="[[rootPath]]/[[ctreeKey]]/history" tabindex="-1">
+                  <iron-icon icon="history"></iron-icon><div class="tabLabel">HISTORY</div>
+                </a>
+              </paper-tab>
+            </paper-tabs>
+            <paper-tooltip class="tabTooltip" for="suggestedTab" offset="-8">Suggested</paper-tooltip>
+            <paper-tooltip class="tabTooltip" for="bookmarksTab" offset="-8">Bookmarks</paper-tooltip>
+            <paper-tooltip class="tabTooltip" for="historyTab" offset="-8">History</paper-tooltip>
+          </app-toolbar> -->
+
+        </app-header>
+
+        <iron-list id="elementPreviewList" items="[[pageListItems]]" as="item" grid>
+          <!-- HACK: added  hidden$="[[!item]]" to prevent phantom items from being added -->
+          <template>
+            <ctree-element-preview ctree-key="[[page]]" list-item="[[item]]" hidden$="[[!item]]"></ctree-element-preview>
+          </template>
+
+          <div id="loadingIndicator" hidden$="[[!loadingListItems]]">
+            <paper-spinner active$="[[loadingListItems]]"></paper-spinner> Loading more
+          </div>
+        </iron-list>
+
+        <iron-scroll-threshold id="scrollThreshold"
+            lower-threshold="500"
+            scroll-target="elementPreviewList"
+            on-lower-threshold="loadMoreListItems">
+        </iron-scroll-threshold>
+
+        <!-- <paper-fab id="addButton" icon="add" title="Add" on-tap="_addElement"></paper-fab> -->
+
+        <!-- Notification drawer -->
+        <app-drawer id="notificationsDrawer" class="notifications-drawer" align="end" on-app-drawer-transitioned="notificationsDrawerTransitioned">
+          <div class="notifications-content" align="left">
+            <div class="notifications-header">
+              <div>Notifications</div>
+              <paper-icon-button on-tap="clearNotifications" icon="playlist-add-check"></paper-icon-button>
+            </div>
+            <iron-list items="[[notifications]]" as="item">
+              <template>
+                <!-- TODO -->
+              </template>
+            </iron-list>
+          </div>
+        </app-drawer>
+      </app-header-layout>
+    <!-- </app-drawer-layout> -->
+  </template>
+
+  <script>
+    class CTreeCatalog extends Polymer.Element {
+
+      static get is() { return 'ctree-catalog'; }
+
+      static get properties() {
+        return {
+          rootPath: {
+            type: String,
+            value: ''
+          },
+
+          page: {
+            type: String,
+            observer: '_pageChanged',
+          },
+
+          searchText: {
+            type: String,
+            observer: '_searchTextChanged',
+            value: function() {
+              return '';
+            }
+          },
+
+          navList: {
+            type: Array,
+            value: function() {
+              return [];
+            }
+          },
+
+          notifications: Array,
+        };
+      }
+
+      static get observers() {
+        return [
+          '_dialogParamChanged(queryParams.d)',
+          '_pathChanged(path)',
+          '_subpageChanged(subpage)',
+          '_loadingListItemsChanged(loadingListItems)',
+        ];
+      }
+
+      showSearch() {
+        // TODO: initiate search input
+      }
+
+      showNotifications() {
+        // TODO: show notifications in dialog below button when larger width (i.e. not on phones)
+    	   this.$.notificationsDrawer.toggle();
+      }
+
+      notificationsDrawerTransitioned() {
+        this.$.elementPreviewList.style.overflowY = this.$.notificationsDrawer.opened ? "hidden" : "auto";
+      }
+
+      clearNotifications() {
+        // TODO: clear all notifications & update notifications indicator in header
+      }
+
+      showAccountDialog() {
+        var dialog = this.$.userDialog;
+        // TODO: show account details in account dialog
+        dialog.page = 'details';
+        dialog.open();
+      }
+
+      showAccountStats() {
+        var dialog = this.$.userDialog;
+        // TODO: show account stats in account dialog
+        dialog.page = 'stats';
+        dialog.open();
+      }
+
+      loadMoreListItems() {
+        if (this.$.importLoader.loaded) {
+          this.$.loader.loadCurrent();
+        } else {
+          this.$.importLoader.load();
+        }
+      }
+
+      _clearSearch() {
+        this.searchText = '';
+      }
+
+      _getCTreeSaveIcon(saved) {
+        return saved ? 'bookmark' : 'bookmark-border';
+      }
+
+      _toggleCTreeSaved() {
+        // TODO: determine which ctree this was clicked for and toggle its data.saved value
+      }
+
+      _importLoaderLoadingChanged(e) {
+        if (!e.detail.value && this.$.importLoader.loaded
+            && !this.$.importPreview.loading && !this.$.importPreview.loaded) {
+          this.$.importPreview.load();
+          this.loadMoreListItems();
+        }
+      }
+
+      _loadingListItemsChanged(loadingListItems) {
+        if (!loadingListItems) {
+          this.$.scrollThreshold.clearTriggers();
+        }
+      }
+
+      _getCTreeList() {
+        // TODO: make conditional on if search is active and what search text is
+        /*if (this.navList) {
+          this.navList.length = 0;
+        } else {
+          this.navList = [];
+        }*/
+        var newNavList = [];
+        var searchTextLower = this.searchText ? this.searchText.toLowerCase() : '';
+        if (CTree.firebaseConfig) {
+          // TODO: get list of cTrees from Firebase instead of using hardcoded pages
+        } else {
+          for (var i = 0; i < ctreeSavedPages.length; i++) {
+            var name = ctreeSavedPages[i];
+            var pageData = ctreePages[name];
+            if (!pageData.icon.startsWith(this.rootPath)) {
+              pageData.icon = this.rootPath + pageData.icon;
+            }
+
+            if (this.searchText) {
+              if (pageData.label.toLowerCase().indexOf(searchTextLower) !== -1) {
+                  newNavList.push({name: name, data: pageData});
+              }
+            } else {
+              if (pageData.saved) {
+                newNavList.push({name: name, data: pageData});
+              }
+            }
+          }
+        }
+
+        return newNavList;
+      }
+
+      _dialogParamChanged(dialogParam) {
+        if (dialogParam === 'element') {
+          this.$.elementDialog.open();
+        } else if (dialogParam === 'user') {
+          this.$.userDialog.open();
+        }
+      }
+
+      _pathChanged(fullPath) {
+        if (fullPath.startsWith(this.rootPath)) {
+          fullPath = fullPath.substr(this.rootPath.length);
+        }
+        var pathSegments = fullPath.split('/');
+        if (pathSegments.length > 1) {
+          var page;
+          // TODO: default to
+          if (CTree.firebaseConfig || ctreeSavedPages.indexOf(pathSegments[1]) >= 0) {
+            page = pathSegments[1];
+          } else if (CTree.firebaseConfig) {
+            // TODO: default to something other than test
+            page = "test"
+          } else {
+            // default to first saved page
+            page = ctreeSavedPages[0];
+          }
+          var subpage;
+          if (pathSegments.length > 2) {
+            subpage = pathSegments[2];
+            if (subpage != 'bookmarked' && subpage != 'history') {
+              subpage = 'suggested';
+            }
+          } else {
+            subpage = 'suggested';
+          }
+        } else {
+          if (CTree.firebaseConfig) {
+            page = "test"
+          } else {
+            page = ctreeSavedPages[0];
+          }
+          subpage = 'suggested';
+        }
+        var forceSubpageChanged = (this.page != page && this.subpage == subpage);
+        this.page = page;
+        this.subpage = subpage;
+        if (forceSubpageChanged) {
+          this._subpageChanged(subpage);
+        }
+      }
+
+      _pageChanged(page) {
+        if (this.rootPath && this.rootPath.length > 0) {
+          this.ctreeKey = this.rootPath + (page && page.length > 0 ? '/' + page : '');
+        } else {
+          this.ctreeKey = page;
+        }
+      }
+
+      _searchTextChanged(searchText) {
+        // TODO:
+      }
+
+      _subpageChanged(subpage) {
+        this.$.loader.currentName = subpage;
+        this.$.scrollThreshold.clearTriggers();
+        // This must be delayed to prevent issue with rootPath being set after trying to load items, which triggers loading component
+        Polymer.RenderStatus.afterNextRender(this, () => {
+          if (!this.$.importLoader.loaded || this.$.loader.currentItems.length == 0) {
+            this.loadMoreListItems();
+          }
+        });
+      }
+
+      // TODO: respond to element changes via the ctree element loader
+      _bookmarkChanged(e) {
+        var element = e.detail.element;
+        // TODO: remove event from bookmarked list (may not be found)
+        if (e.detail.bookmarked) {
+          // TODO: add event to top of bookmarked list
+        }
+        // TODO: start checking for duplicates as loading bookmarked items (may have added manually)
+      }
+
+      _getTempNotifications() {
+    	  // TODO:
+    	  return [];
+      }
+
+      _addElement() {
+        var dialog = this.$.newElementDialog;
+        // TODO: add parameters if needed
+        dialog.open();
+      }
+    }
+
+    // Register custom element definition using standard platform API
+    customElements.define(CTreeCatalog.is, CTreeCatalog);
+  </script>
+</dom-module>

--- a/src/ctree-app/ctree-landing.html
+++ b/src/ctree-app/ctree-landing.html
@@ -1,0 +1,378 @@
+<!--
+@license
+Copyright (c) 2017 Foundation For an Innovative Future (InnovativeFuture.org)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or any
+later version.
+
+Foundation For an Innovative Future reserves the right to release the
+covered work, in part or in whole, under a different open source
+license and/or with specific copyleft exclusions.  Such a release
+would not invalidate the license for this project, although the
+project released with a modified license would not be considered
+part of this covered work or subject to the copyleft portions of this
+license even if the projects are identical.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Please email contact@innovativeFuture.org for inquiries related to
+this license.
+-->
+
+<link rel="import" href="../../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../../bower_components/app-layout/app-drawer/app-drawer.html">
+<link rel="import" href="../../bower_components/app-layout/app-scroll-effects/app-scroll-effects.html">
+<link rel="import" href="../../bower_components/app-layout/app-header/app-header.html">
+<link rel="import" href="../../bower_components/app-layout/app-header-layout/app-header-layout.html">
+<link rel="import" href="../../bower_components/app-layout/app-toolbar/app-toolbar.html">
+<link rel="import" href="../../bower_components/iron-list/iron-list.html">
+<link rel="import" href="../../bower_components/iron-location/iron-location.html">
+<link rel="import" href="../../bower_components/iron-location/iron-query-params.html">
+<link rel="import" href="../../bower_components/iron-meta/iron-meta.html">
+<link rel="import" href="../../bower_components/iron-scroll-target-behavior/iron-scroll-target-behavior.html">
+<link rel="import" href="../../bower_components/iron-selector/iron-selector.html">
+<link rel="import" href="../../bower_components/paper-button/paper-button.html">
+<link rel="import" href="../../bower_components/paper-fab/paper-fab.html">
+<link rel="import" href="../../bower_components/paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../../bower_components/paper-input/paper-input.html">
+<link rel="import" href="../../bower_components/paper-spinner/paper-spinner.html">
+<link rel="import" href="../../bower_components/paper-tabs/paper-tabs.html">
+<link rel="import" href="../../bower_components/paper-tooltip/paper-tooltip.html">
+
+<link rel="import" href="../ctree-dialogs/ctree-element-dialog-accessor.html">
+<link rel="import" href="../ctree-dialogs/ctree-new-element-dialog-accessor.html">
+<link rel="import" href="../ctree-dialogs/ctree-user-dialog-accessor.html">
+<link rel="import" href="../ctree-import/ctree-import.html">
+<link rel="import" href="../ctree-toggle-button/ctree-toggle-button.html">
+
+<link rel="import" href="ctree-app-icon.html">
+<link rel="import" href="icons.html">
+
+<dom-module id="ctree-landing">
+  <template>
+    <style>
+      :host {
+        display: block;
+        --app-primary-color: #5F9F00;
+        --app-secondary-color: black;
+      }
+      #mainLayout app-toolbar {
+        padding: 0 8px 0 0;
+      }
+      #content {
+        @apply --layout-fit;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+      }
+      #headerTitle, #menuButton {
+        display: none;
+      }
+      app-drawer ul {
+        text-align: left !important;
+      }
+      app-header-layout {
+        height: 100vh;
+      }
+      app-header {
+        background-color: #4F7F00;
+        color: #fff;
+      }
+      app-header paper-icon-button {
+        --paper-icon-button-ink-color: white;
+      }
+      paper-tab {
+        width: 0;
+      }
+      paper-tab[link] a {
+        @apply --layout-horizontal;
+        @apply --layout-center-center;
+        color: #fff;
+        text-decoration: none;
+      }
+      paper-tab iron-icon {
+        padding-right: 2px;
+      }
+      .tabTooltip {
+        visibility: hidden;
+      }
+      paper-button {
+        text-transform: none;
+      }
+      paper-button iron-icon {
+        padding-right: 8px;
+      }
+      paper-icon-button[hidden] {
+        display: none !important;
+      }
+      @media (max-width: 500px) {
+        paper-tabs {
+          display: none;
+        }
+        #headerTitle, #menuButton {
+          display: inline-block;
+        }
+      }
+    </style>
+
+    <iron-meta key="rootPath" value="{{rootPath}}"></iron-meta>
+    <ctree-import id="importLoader" href="/src/ctree-loader/ctree-list-loader-test.html" on-loading-changed="_importLoaderLoadingChanged"></ctree-import>
+    <ctree-import id="importPreview" href="/src/ctree-element-preview/ctree-element-preview.html"></ctree-import>
+
+    <iron-location path="{{path}}" query="{{query}}" dwell-time="800"></iron-location>
+    <iron-query-params id="params" params-string="{{query}}" params-object="{{queryParams}}"></iron-query-params>
+    <ctree-element-dialog-accessor id="elementDialog" ctree-key="[[ctreeKey]]"></ctree-element-dialog-accessor>
+    <ctree-new-element-dialog-accessor id="newElementDialog" ctree-key="[[ctreeKey]]"></ctree-new-element-dialog-accessor>
+    <ctree-user-dialog-accessor id="userDialog" ctree-key="[[ctreeKey]]"></ctree-user-dialog-accessor>
+
+    <app-header-layout id="mainLayout" has-scrolling-region>
+      <app-header slot="header" reveals effects="waterfall">
+        <app-toolbar>
+          <ctree-app-icon></ctree-app-icon>
+          <div id="headerTitle" main-title>Collaboration Trees</div>
+          <paper-icon-button id="menuButton" icon="menu" on-tap="_toggleDrawer"></paper-icon-button>
+          <paper-tabs selected="{{section}}" attr-for-selected="name" fallback-selection="overview" bottom-item style="margin-left: 66px">
+            <paper-tab id="overviewTab" name="overview" link>
+              <a href="[[rootPath]]?section=overview" tabindex="-1">
+                Overview
+              </a>
+            </paper-tab>
+            <paper-tab id="feedbackTab" name="feedback" link>
+              <a href="[[rootPath]]?section=feedback" tabindex="-1">
+                Feedback
+              </a>
+            </paper-tab>
+            <paper-tab id="featuresTab" name="features" link>
+              <a href="[[rootPath]]?section=features" tabindex="-1">
+                Features
+              </a>
+            </paper-tab>
+            <paper-tab id="ctreeTab" name="ctree" link>
+              <a href="[[rootPath]]?section=ctree" tabindex="-1">
+                cTree
+              </a>
+            </paper-tab>
+            <paper-tab id="participateTab" name="participate" link>
+              <a href="[[rootPath]]?section=participate" tabindex="-1">
+                Participate
+              </a>
+            </paper-tab>
+          </paper-tabs>
+        </app-toolbar>
+      </app-header>
+
+      <div id="content">
+        <div id="overview" style="height: 100vh; background-color: #FF0000">
+        </div><div id="feedback" style="display: inline-block; width: 100vw; background-color: #00FF00">
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+        </div><div id="features" style="display: inline-block; width: 100vw; background-color: #0000FF">
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+        </div><div id="ctree" style="display: inline-block; width: 100vw; background-color: #FF00FF">
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+        </div><div id="participate" style="display: inline-block; width: 100vw; background-color: #FFFF00">
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+          <p>W</p>
+        </div>
+      </div>
+    </app-header-layout>
+
+    <app-drawer id="navDrawer" class="nav-drawer" align="right" position="right" swipe-open>
+      <ul>
+        <li>
+          <a href="[[rootPath]]?section=overview" on-click="_toggleDrawer">
+            Overview
+          </a>
+        </li><li>
+          <a href="[[rootPath]]?section=feedback" on-click="_toggleDrawer">
+            Feedback
+          </a>
+        </li><li>
+          <a href="[[rootPath]]?section=features" on-click="_toggleDrawer">
+            Features
+          </a>
+        </li><li>
+          <a href="[[rootPath]]?section=ctree" on-click="_toggleDrawer">
+            cTree Examples
+          </a>
+        </li><li>
+          <a href="[[rootPath]]?section=participate" on-click="_toggleDrawer">
+            Participate
+          </a>
+        </li>
+      </ul>
+    </app-drawer>
+  </template>
+
+  <script>
+    class CTreeLanding extends Polymer.mixinBehaviors([Polymer.IronScrollTargetBehavior], Polymer.Element) {
+
+      static get is() { return 'ctree-landing'; }
+
+      static get properties() {
+        return {
+          rootPath: {
+            type: String,
+            value: '',
+          },
+
+          section: String,
+
+          _suppressInferSection: {
+            type: Boolean,
+            value: false,
+          },
+        };
+      }
+
+      static get observers() {
+        return [
+          '_dialogParamChanged(queryParams.section)',
+        ];
+      }
+
+      ready() {
+        super.ready();
+        // TODO:
+        this.scrollTarget = this.$.content;
+      }
+
+      _toggleDrawer() {
+        this.$.navDrawer.toggle();
+        console.log("toggle drawer");
+      }
+
+      _scrollHandler() {
+        // throttle the work on the scroll event
+        var THROTTLE_THRESHOLD = 200;
+        if (!this.isDebouncerActive('_updateSection') && !this._suppressInferSection) {
+          this.debounce('_updateSection', function() {
+            this._updateSection();
+          }, THROTTLE_THRESHOLD);
+        }
+      }
+
+      _updateSection() {
+        var children = this.scrollTarget.childNodes;
+        var currentChild = null;
+        var contentMiddle = this.scrollTarget.offsetHeight / 2;
+        for (var i = 0; i < children.length; i++) {
+          if (children[i].id) {
+            if (currentChild != null && this.scrollTarget.scrollTop < children[i].offsetTop) {
+              if (this.scrollTarget.scrollTop + this.scrollTarget.offsetHeight - children[i].offsetTop - children[i].offsetHeight >= 0) {
+                currentChild = children[i];
+              }
+              break;
+            }
+            currentChild = children[i];
+          }
+        }
+        this.section = currentChild.id;
+      }
+
+      _dialogParamChanged(section) {
+        if (section && section.length > 0) {
+          this._scrollTo(this.$.content, this.$[section].offsetTop, 500);
+          this.section = section
+        }
+      }
+
+      _scrollTo(container, position, duration) {
+        var MILLIS_PER_FRAME = 16
+        var t = this
+        t._suppressInferSection = true;
+        var scrollStep = (position - container.scrollTop) / (duration / MILLIS_PER_FRAME);
+        var scrollInterval = setInterval(function() {
+          if (Math.abs(position - container.scrollTop) > Math.abs(scrollStep)) {
+            var newPosition = Math.floor(container.scrollTop + scrollStep)
+            container.scrollTop = newPosition;
+            if (container.scrollTop != newPosition) {
+              t._suppressInferSection = false;
+              clearInterval(scrollInterval)
+            }
+          } else {
+            container.scrollTop = position;
+            t._suppressInferSection = false;
+            clearInterval(scrollInterval);
+          }
+        }, MILLIS_PER_FRAME);
+      }
+    }
+
+    // Register custom element definition using standard platform API
+    customElements.define(CTreeLanding.is, CTreeLanding);
+  </script>
+</dom-module>


### PR DESCRIPTION
Updates the app structure to support multiple contexts, like landing page vs. element catalog.  This is in preparation for adding a new context for #113, which will be implemented as a new context instead of a dialog to maximize viewable space and work better when opening elements.  This also prepares the code for easier merging of the landing-page branch, since it merges the fundamental refactoring done to start that branch.

This needs to be merged soon, as it's a hard refactor of the ctree-app element, so any other changes to ctree-app will be need to be manually moved to ctree-catalog until this is merged.